### PR TITLE
Create vet animal table

### DIFF
--- a/data.sql
+++ b/data.sql
@@ -1,5 +1,8 @@
 /* Populate database with sample data. */
 
-INSERT INTO animals (name) VALUES ('Luna');
-INSERT INTO animals (name) VALUES ('Daisy');
-INSERT INTO animals (name) VALUES ('Charlie');
+-- Insert Data INTO animals Table
+INSERT INTO animals (name, date_of_birth, escape_attempts, neutered, weight_kg)
+VALUES ('Agumon', '2020-02-03', 0, true, 10.23),
+       ('Gabumon', '2018-11-15', 2, true, 8),
+       ('Pikachu', '2021-01-07', 1, false, 15.04),
+       ('Devimon', '2017-05-12', 5, true, 11);

--- a/queries.sql
+++ b/queries.sql
@@ -1,3 +1,25 @@
 /*Queries that provide answers to the questions from all projects.*/
 
-SELECT * from animals WHERE name = 'Luna';
+-- All animals whose name ends in "mon"
+SELECT * FROM animals WHERE name LIKE '%mon';
+
+-- Name of all animals born between 2016 and 2019
+SELECT * FROM animals WHERE date_of_birth >= '2016-01-01' AND date_of_birth <= '2019-12-31';
+
+-- Name of all animals that are neutered and have less than 3 escape attempts
+SELECT name FROM animals WHERE neutered = true AND escape_attempts < 3;
+
+-- Date of birth of all animals named either "Agumon" or "Pikachu"
+SELECT date_of_birth FROM animals WHERE name IN ('Agumon', 'Pikachu');
+
+-- Name and Escape attempts of animals that weigh more than 10.5kg
+SELECT name, escape_attempts FROM animals WHERE weight_kg > 10.5;
+
+-- All animals that are neutered
+SELECT * FROM animals WHERE neutered = true;
+
+-- All animals not named Gabumon
+SELECT * FROM animals WHERE name <> 'Gabumon';
+
+-- all animals with a weight between 10.4kg and 17.3kg
+SELECT * FROM animals WHERE weight_kg BETWEEN 10.4 AND 17.3;

--- a/schema.sql
+++ b/schema.sql
@@ -1,5 +1,17 @@
 /* Database schema to keep the structure of entire database. */
 
+-- Create vet_clinic Database 
+CREATE DATABASE vet_clinic;
+
+-- Connect to vet_clinic Database
+\c vet_clinic;
+
+-- Create animals Table
 CREATE TABLE animals (
-    name varchar(100)
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255),
+  date_of_birth DATE,
+  escape_attempts INTEGER,
+  neutered BOOLEAN,
+  weight_kg DECIMAL
 );


### PR DESCRIPTION
This pull request involves,

-  Created a new database called vet_clinic.
-  Created a table named animals with various columns
-  Copied the SQL used in the previous point into the schema.sql and data.sql files in the generated repository.
-  Take a screenshot of the results of queries.
-  Added the screenshot with the results of queries Pull Request description.

## Queries: 

- [ ]  All animals whose name ends in "mon"
![sql1](https://github.com/yusufobr/vet-clinic/assets/52011598/2fa59add-4c95-4b81-a1f3-35fd34e23869)
- [ ]  Name of all animals born between 2016 and 2019
![sql2](https://github.com/yusufobr/vet-clinic/assets/52011598/94b7667e-0dfd-478e-a816-fb0f56412570)
- [ ]  Name of all animals that are neutered and have less than 3 escape attempts
![sql3](https://github.com/yusufobr/vet-clinic/assets/52011598/11ff8209-a508-4531-82a3-43eb7439e909)
- [ ]  Date of birth of all animals named either "Agumon" or "Pikachu"
![sql4](https://github.com/yusufobr/vet-clinic/assets/52011598/14afc4b9-0ed7-4716-a72d-8544b8899318)
- [ ]  Name and Escape attempts of animals that weigh more than 10.5kg
![sql5](https://github.com/yusufobr/vet-clinic/assets/52011598/fbf71913-2678-484d-ad5e-8774a1040190)
- [ ]  All animals that are neutered
![sql6](https://github.com/yusufobr/vet-clinic/assets/52011598/bf7dc9a6-3356-4a1d-acae-83a2cdd73bca)
- [ ]  All animals not named Gabumon
![sql7](https://github.com/yusufobr/vet-clinic/assets/52011598/eb0f20fb-2be4-47cc-b64c-01a2101be740)
- [ ]  All animals with a weight between 10.4kg and 17.3kg
![sql8](https://github.com/yusufobr/vet-clinic/assets/52011598/bd8e3c7b-9273-46f3-ae92-0a90535f4a3b)

